### PR TITLE
fix: re-enable checkstyle on java 16 branch

### DIFF
--- a/build-logic/src/main/kotlin/moonshine.api.gradle.kts
+++ b/build-logic/src/main/kotlin/moonshine.api.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 plugins {
     id("moonshine.publishing")
     id("net.kyori.indra")
-//    id("net.kyori.indra.checkstyle")
+    id("net.kyori.indra.checkstyle")
     id("net.kyori.indra.license-header")
     id("com.adarshr.test-logger")
     java
@@ -12,11 +12,9 @@ plugins {
     jacoco
 }
 
-//indra {
-//    checkstyle {
-//        toolVersion = "9.0"
-//    }
-//}
+indra {
+    checkstyle("9.0")
+}
 
 testlogger {
     theme = ThemeType.MOCHA_PARALLEL


### PR DESCRIPTION
not sure why setting the toolVersion makes it use the wrong version but using indra's checkstyle version setter makes it work as expected