### PR TITLE
Support nested message sections

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+end_of_line = lf

--- a/build-logic/src/main/kotlin/moonshine.api.gradle.kts
+++ b/build-logic/src/main/kotlin/moonshine.api.gradle.kts
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
     val libs = (project as ExtensionAware).extensions.getByName("libs") as LibrariesForLibs
-    api(libs.checkerframework)
+    compileOnlyApi(libs.checkerframework)
 
     testImplementation(libs.bundles.testing.api)
     testRuntimeOnly(libs.bundles.testing.runtime)

--- a/core/src/main/java/net/kyori/moonshine/MoonshineChild.java
+++ b/core/src/main/java/net/kyori/moonshine/MoonshineChild.java
@@ -1,0 +1,80 @@
+/*
+ * moonshine - A localisation library for Java.
+ * Copyright (C) Mariell Hoversholm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.kyori.moonshine;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.NavigableSet;
+import net.kyori.moonshine.exception.scan.UnscannableMethodException;
+import net.kyori.moonshine.message.IMessageRenderer;
+import net.kyori.moonshine.message.IMessageSender;
+import net.kyori.moonshine.message.IMessageSource;
+import net.kyori.moonshine.placeholder.IPlaceholderResolver;
+import net.kyori.moonshine.receiver.IReceiverLocatorResolver;
+import net.kyori.moonshine.strategy.IPlaceholderResolverStrategy;
+import net.kyori.moonshine.util.Weighted;
+
+public final class MoonshineChild<R, I, O, F> extends Moonshine<R, I, O, F> {
+  private final Moonshine<R, I, O, F> parent;
+
+  public MoonshineChild(
+      final Type proxiedType,
+      final ClassLoader proxyClassLoader,
+      final Moonshine<R, I, O, F> parent,
+      final String inheritedKey)
+      throws UnscannableMethodException {
+    super(proxiedType, proxyClassLoader);
+    this.parent = parent;
+    scanMethods(inheritedKey + proxiedTypeKey(), proxyClassLoader);
+  }
+
+  @Override
+  public Moonshine<R, I, O, F> parent() {
+    return this.parent;
+  }
+
+  @Override
+  public IPlaceholderResolverStrategy<R, I, F> placeholderResolverStrategy() {
+    return this.parent.placeholderResolverStrategy();
+  }
+
+  @Override
+  public NavigableSet<Weighted<? extends IReceiverLocatorResolver<? extends R>>> weightedReceiverLocatorResolvers() {
+    return this.parent.weightedReceiverLocatorResolvers();
+  }
+
+  @Override
+  public Map<Type, NavigableSet<Weighted<? extends IPlaceholderResolver<? extends R, ?, ? extends F>>>> weightedPlaceholderResolvers() {
+    return this.parent.weightedPlaceholderResolvers();
+  }
+
+  @Override
+  public IMessageSource<R, I> messageSource() {
+    return this.parent.messageSource();
+  }
+
+  @Override
+  public IMessageRenderer<R, I, O, F> messageRenderer() {
+    return this.parent.messageRenderer();
+  }
+
+  @Override
+  public IMessageSender<R, O> messageSender() {
+    return this.parent.messageSender();
+  }
+}

--- a/core/src/main/java/net/kyori/moonshine/MoonshineInvocationHandler.java
+++ b/core/src/main/java/net/kyori/moonshine/MoonshineInvocationHandler.java
@@ -84,6 +84,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
     }
 
     final var moonshineMethod = this.moonshine.scannedMethod(method);
+
+    if (moonshineMethod.messageSectionProxy() != null) {
+      return moonshineMethod.messageSectionProxy();
+    }
+
     final R receiver = moonshineMethod.receiverLocator().locate(method, proxy, args);
     final I intermediateMessage = this.moonshine.messageSource().messageOf(receiver, moonshineMethod.messageKey());
     final var resolvedPlaceholders =

--- a/core/src/main/java/net/kyori/moonshine/MoonshineRoot.java
+++ b/core/src/main/java/net/kyori/moonshine/MoonshineRoot.java
@@ -1,0 +1,93 @@
+/*
+ * moonshine - A localisation library for Java.
+ * Copyright (C) Mariell Hoversholm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.kyori.moonshine;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableSet;
+import net.kyori.moonshine.annotation.meta.ThreadSafe;
+import net.kyori.moonshine.exception.scan.UnscannableMethodException;
+import net.kyori.moonshine.message.IMessageRenderer;
+import net.kyori.moonshine.message.IMessageSender;
+import net.kyori.moonshine.message.IMessageSource;
+import net.kyori.moonshine.placeholder.IPlaceholderResolver;
+import net.kyori.moonshine.receiver.IReceiverLocatorResolver;
+import net.kyori.moonshine.strategy.IPlaceholderResolverStrategy;
+import net.kyori.moonshine.util.Weighted;
+
+@ThreadSafe
+final class MoonshineRoot<R, I, O, F> extends Moonshine<R, I, O, F> {
+  private final IPlaceholderResolverStrategy<R, I, F> placeholderResolverStrategy;
+  private final IMessageSource<R, I> messageSource;
+  private final IMessageRenderer<R, I, O, F> messageRenderer;
+  private final IMessageSender<R, O> messageSender;
+  private final NavigableSet<Weighted<? extends IReceiverLocatorResolver<? extends R>>> weightedReceiverLocatorResolvers;
+  private final Map<Type, NavigableSet<Weighted<? extends IPlaceholderResolver<? extends R, ?, ? extends F>>>> weightedPlaceholderResolvers;
+
+  MoonshineRoot(
+      final Type proxiedType,
+      final ClassLoader classLoader,
+      final IPlaceholderResolverStrategy<R, I, F> placeholderResolverStrategy,
+      final IMessageSource<R, I> messageSource,
+      final IMessageRenderer<R, I, O, F> messageRenderer,
+      final IMessageSender<R, O> messageSender,
+      final NavigableSet<Weighted<? extends IReceiverLocatorResolver<? extends R>>> weightedReceiverLocatorResolvers,
+      final Map<Type, NavigableSet<Weighted<? extends IPlaceholderResolver<? extends R, ?, ? extends F>>>> weightedPlaceholderResolvers)
+      throws UnscannableMethodException {
+    super(proxiedType, classLoader);
+    this.placeholderResolverStrategy = placeholderResolverStrategy;
+    this.messageSource = messageSource;
+    this.messageRenderer = messageRenderer;
+    this.messageSender = messageSender;
+    this.weightedReceiverLocatorResolvers = Collections.unmodifiableNavigableSet(weightedReceiverLocatorResolvers);
+    this.weightedPlaceholderResolvers = Collections.unmodifiableMap(weightedPlaceholderResolvers);
+    scanMethods(proxiedTypeKey(), classLoader);
+  }
+
+  @Override
+  public IPlaceholderResolverStrategy<R, I, F> placeholderResolverStrategy() {
+    return this.placeholderResolverStrategy;
+  }
+
+  @Override
+  public NavigableSet<Weighted<? extends IReceiverLocatorResolver<? extends R>>>
+      weightedReceiverLocatorResolvers() {
+    return this.weightedReceiverLocatorResolvers;
+  }
+
+  @Override
+  public Map<Type, NavigableSet<Weighted<? extends IPlaceholderResolver<? extends R, ?, ? extends F>>>> weightedPlaceholderResolvers() {
+    return this.weightedPlaceholderResolvers;
+  }
+
+  @Override
+  public IMessageSource<R, I> messageSource() {
+    return this.messageSource;
+  }
+
+  @Override
+  public IMessageRenderer<R, I, O, F> messageRenderer() {
+    return this.messageRenderer;
+  }
+
+  @Override
+  public IMessageSender<R, O> messageSender() {
+    return this.messageSender;
+  }
+}

--- a/core/src/main/java/net/kyori/moonshine/annotation/MessageSection.java
+++ b/core/src/main/java/net/kyori/moonshine/annotation/MessageSection.java
@@ -1,0 +1,92 @@
+/*
+ * moonshine - A localisation library for Java.
+ * Copyright (C) Mariell Hoversholm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.kyori.moonshine.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This allows developers to have nested messages and configure given properties of a message
+ * section.<br>
+ * For the root section adding this annotation is optional, but for nested sections it's not.<br>
+ * <br>
+ * Examples:<br>
+ * A message with key 'hello.world-moonshine' could be added as follows:
+ *
+ * <pre>{@code
+ * @MessageSection("hello")
+ * public interface HelloSection {
+ *     WorldSection world();
+ *
+ *     @MessageSection("world", delimiter='-')
+ *     interface WorldSection {
+ *         @Message("moonshine")
+ *         String moonshine(@Receiver User user);
+ *     }
+ * }
+ * }</pre>
+ *
+ * An example where there is no message section annotation on the root section. The following
+ * example results in the key 'hello.world':
+ *
+ * <pre>{@code
+ * public interface RootSection {
+ *     HelloSection hello();
+ *
+ *     @MessageSection("hello")
+ *     interface HelloSection {
+ *         @Message("world")
+ *         String world(@Receiver User user);
+ *     }
+ * }
+ * }</pre>
+ *
+ * Adding the {@link Message @Message} annotation to the method referencing a message section is
+ * supported. As well as having an empty key to prepend. The following example results in the key
+ * 'hello.world-moonshine':
+ *
+ * <pre>{@code
+ * @MessageSection("hello")
+ * public interface HelloSection {
+ *     @Message("world")
+ *     WorldSection world();
+ *
+ *     @MessageSection(delimiter='-')
+ *     interface WorldSection {
+ *         @Message("moonshine")
+ *         String moonshine(@Receiver User user);
+ *     }
+ * }
+ * }</pre>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MessageSection {
+  /** The default delimiter */
+  char DEFAULT_DELIMITER = '.';
+
+  /** Returns the message key to prepend to all messages in this section. */
+  String value() default "";
+
+  /** Returns the delimiter. */
+  char delimiter() default DEFAULT_DELIMITER;
+}

--- a/core/src/main/java/net/kyori/moonshine/model/MoonshineMethod.java
+++ b/core/src/main/java/net/kyori/moonshine/model/MoonshineMethod.java
@@ -72,7 +72,7 @@ public final class MoonshineMethod<R> {
               proxyClassLoader,
               moonshine,
               this.messageKey
-      );
+      ).proxy();
     }
     this.messageSectionProxy = messageSectionProxy;
   }

--- a/core/src/main/java/net/kyori/moonshine/model/MoonshineMethod.java
+++ b/core/src/main/java/net/kyori/moonshine/model/MoonshineMethod.java
@@ -17,16 +17,17 @@
  */
 package net.kyori.moonshine.model;
 
-import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.Iterator;
 import net.kyori.moonshine.Moonshine;
+import net.kyori.moonshine.MoonshineChild;
 import net.kyori.moonshine.annotation.Message;
+import net.kyori.moonshine.annotation.MessageSection;
 import net.kyori.moonshine.annotation.meta.ThreadSafe;
 import net.kyori.moonshine.exception.scan.MissingMessageAnnotationException;
 import net.kyori.moonshine.exception.scan.NoReceiverLocatorFoundException;
 import net.kyori.moonshine.exception.scan.UnscannableMethodException;
-import net.kyori.moonshine.message.IMessageSource;
 import net.kyori.moonshine.receiver.IReceiverLocator;
 import net.kyori.moonshine.receiver.IReceiverLocatorResolver;
 import net.kyori.moonshine.util.Weighted;
@@ -40,65 +41,96 @@ import org.checkerframework.dataflow.qual.Pure;
  */
 @ThreadSafe
 public final class MoonshineMethod<R> {
-  /**
-   * The owning/declaring type of this method.
-   */
-  private final TypeToken<?> owner;
-
-  /**
-   * The {@link Method reflected method} of this method.
-   */
+  private final Type owner;
   private final Method reflectMethod;
-
-  /**
-   * The key for the message to pass to a {@link IMessageSource message source}.
-   */
+  private final @Nullable Object messageSectionProxy;
   private final String messageKey;
 
-  /**
-   * The locator for a given receiver of this message.
-   */
-  private final IReceiverLocator<? extends R> receiverLocator;
+  private final @Nullable IReceiverLocator<? extends R> receiverLocator;
 
-  public MoonshineMethod(final Moonshine<R, ?, ?, ?> moonshine, final TypeToken<?> owner, final Method reflectMethod)
+  public MoonshineMethod(
+          final Moonshine<R, ?, ?, ?> moonshine,
+          final Type owner,
+          final ClassLoader proxyClassLoader,
+          final Method reflectMethod,
+          final String sectionFullKey,
+          final char delimiter)
       throws UnscannableMethodException {
     this.owner = owner;
     this.reflectMethod = reflectMethod;
 
-    final Message message = this.findMessageAnnotation();
-    this.messageKey = message.value();
+    final boolean isMessageSection = this.reflectMethod.getReturnType().isAnnotationPresent(MessageSection.class);
 
-    this.receiverLocator = this.findReceiverLocator(moonshine);
+    this.messageKey = this.findMessageKey(sectionFullKey, delimiter, isMessageSection);
+    // todo is IReceiverLocatorResolver needed?
+    this.receiverLocator = isMessageSection ? null : this.findReceiverLocator(moonshine);
+
+    Object messageSectionProxy = null;
+    if (isMessageSection) {
+      messageSectionProxy = new MoonshineChild<>(
+              this.reflectMethod.getGenericReturnType(),
+              proxyClassLoader,
+              moonshine,
+              this.messageKey
+      );
+    }
+    this.messageSectionProxy = messageSectionProxy;
   }
 
+  /**
+   * Returns the owning/declaring type of this method.
+   */
   @Pure
-  public TypeToken<?> owner() {
+  public Type owner() {
     return this.owner;
   }
 
+  /**
+   * Returns the {@link Method reflected method} of this method.
+   */
   @Pure
   public Method reflectMethod() {
     return this.reflectMethod;
   }
 
+  /**
+   * Returns the message section proxy if this method is a message section, otherwise null.
+   */
+  public @Nullable Object messageSectionProxy() {
+    return this.messageSectionProxy;
+  }
+
+  /**
+   * The full key of the message. So this includes the parent key parts if it has any.
+   */
   @Pure
   public String messageKey() {
     return this.messageKey;
   }
 
+  /**
+   * The locator for a given receiver of this message.
+   */
   @Pure
-  public IReceiverLocator<? extends R> receiverLocator() {
+  public @Nullable IReceiverLocator<? extends R> receiverLocator() {
     return this.receiverLocator;
   }
 
-  private Message findMessageAnnotation() throws MissingMessageAnnotationException {
+  private String findMessageKey(final String sectionFullKey, final char delimiter, final boolean isMessageSection) throws MissingMessageAnnotationException {
     final @Nullable Message annotation = this.reflectMethod.getAnnotation(Message.class);
+
     //noinspection ConstantConditions -- this is completely not true. It may be null, per its Javadocs.
     if (annotation == null) {
-      throw new MissingMessageAnnotationException(this.owner.getType(), this.reflectMethod);
+      if (isMessageSection) {
+        return sectionFullKey;
+      }
+      throw new MissingMessageAnnotationException(this.owner, this.reflectMethod);
     }
 
-    return annotation;
+    if (isMessageSection) {
+      return sectionFullKey + annotation.value() + delimiter;
+    }
+    return sectionFullKey + annotation.value();
   }
 
   private IReceiverLocator<? extends R> findReceiverLocator(final Moonshine<R, ?, ?, ?> moonshine)
@@ -110,13 +142,13 @@ public final class MoonshineMethod<R> {
       final IReceiverLocatorResolver<? extends R> receiverLocatorResolver =
           receiverLocatorResolverIterator.next().value();
       final @Nullable IReceiverLocator<? extends R> resolvedLocator =
-          receiverLocatorResolver.resolve(this.reflectMethod, this.owner.getType());
+          receiverLocatorResolver.resolve(this.reflectMethod, this.owner);
 
       if (resolvedLocator != null) {
         return resolvedLocator;
       }
     }
 
-    throw new NoReceiverLocatorFoundException(this.owner.getType(), this.reflectMethod);
+    throw new NoReceiverLocatorFoundException(this.owner, this.reflectMethod);
   }
 }

--- a/core/src/test/java/net/kyori/moonshine/NestedMoonshineTest.java
+++ b/core/src/test/java/net/kyori/moonshine/NestedMoonshineTest.java
@@ -1,3 +1,20 @@
+/*
+ * moonshine - A localisation library for Java.
+ * Copyright (C) Mariell Hoversholm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package net.kyori.moonshine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,70 +30,77 @@ import net.kyori.moonshine.util.Unit;
 import org.junit.jupiter.api.Test;
 
 class NestedMoonshineTest {
-    @Test
-    void simpleNestedMoonshine() throws UnscannableMethodException {
-        SimpleNestedMoonshineRoot root = moonshineWith(SimpleNestedMoonshineRoot.class, (receiver, messageKey) -> {
-            if ("test".equals(messageKey)) {
+  @Test
+  void simpleNestedMoonshine() throws UnscannableMethodException {
+    final SimpleNestedMoonshineRoot root =
+        this.moonshineWith(
+            SimpleNestedMoonshineRoot.class,
+            (receiver, messageKey) -> {
+              if ("test".equals(messageKey)) {
                 return "ok";
-            }
-            return null;
-        });
-        assertEquals("ok", root.child().test());
-    }
+              }
+              return null;
+            });
+    assertEquals("ok", root.child().test());
+  }
 
-    @Test
-    void complexNestedMoonshine() throws UnscannableMethodException {
-        ComplexNestedMoonshineRoot root = moonshineWith(ComplexNestedMoonshineRoot.class, (receiver, messageKey) -> {
-            if ("complex.child.child-test".equals(messageKey)) {
+  @Test
+  void complexNestedMoonshine() throws UnscannableMethodException {
+    final ComplexNestedMoonshineRoot root =
+        this.moonshineWith(
+            ComplexNestedMoonshineRoot.class,
+            (receiver, messageKey) -> {
+              if ("complex.child.child-test".equals(messageKey)) {
                 return "ok";
-            }
-            if ("complex.child.child-oke-ok.done".equals(messageKey)) {
+              }
+              if ("complex.child.child-oke-ok.done".equals(messageKey)) {
                 return "yes";
-            }
-            return null;
-        });
-        assertEquals("ok", root.child().test());
-        assertEquals("yes", root.child().oke().done());
+              }
+              return null;
+            });
+    assertEquals("ok", root.child().test());
+    assertEquals("yes", root.child().oke().done());
+  }
+
+  private <T> T moonshineWith(final Class<T> type, final IMessageSource<Unit, ?> sourced)
+      throws UnscannableMethodException {
+    return Moonshine.<T, Unit>builder(TypeToken.get(type))
+        .receiverLocatorResolver((method, proxy) -> (method1, proxy1, arguments) -> null, 1)
+        .sourced(sourced)
+        .rendered((receiver, intermediateMessage, resolvedPlaceholders, method, owner) -> intermediateMessage)
+        .sent((receiver, renderedMessage) -> {})
+        .resolvingWithStrategy(new StandardPlaceholderResolverStrategy<>(new StandardSupertypeThenInterfaceSupertypeStrategy(false)))
+        .create();
+  }
+
+  interface SimpleNestedMoonshineRoot {
+    SimpleNestedMoonshineChild child();
+
+    @MessageSection
+    interface SimpleNestedMoonshineChild {
+      @Message("test")
+      String test();
     }
+  }
 
-    private <T> T moonshineWith(Class<T> type, IMessageSource<Unit, ?> sourced) throws UnscannableMethodException {
-        return Moonshine.<T, Unit>builder(TypeToken.get(type))
-                .receiverLocatorResolver((method, proxy) -> (method1, proxy1, arguments) -> null, 1)
-                .sourced(sourced)
-                .rendered((receiver, intermediateMessage, resolvedPlaceholders, method, owner) -> intermediateMessage)
-                .sent((receiver, renderedMessage) -> {})
-                .resolvingWithStrategy(new StandardPlaceholderResolverStrategy<>(new StandardSupertypeThenInterfaceSupertypeStrategy(false)))
-                .create();
+  @MessageSection("complex")
+  interface ComplexNestedMoonshineRoot {
+    @Message("child")
+    ComplexNestedMoonshineChild child();
+
+    @MessageSection(value = "child", delimiter = '-')
+    interface ComplexNestedMoonshineChild {
+      @Message("test")
+      String test();
+
+      @Message("oke")
+      ComplexNestedMoonshineChildChild oke();
+
+      @MessageSection("ok")
+      interface ComplexNestedMoonshineChildChild {
+        @Message("done")
+        String done();
+      }
     }
-
-    interface SimpleNestedMoonshineRoot {
-        SimpleNestedMoonshineChild child();
-
-        @MessageSection
-        interface SimpleNestedMoonshineChild {
-            @Message("test")
-            String test();
-        }
-    }
-
-    @MessageSection("complex")
-    interface ComplexNestedMoonshineRoot {
-        @Message("child")
-        ComplexNestedMoonshineChild child();
-
-        @MessageSection(value = "child", delimiter = '-')
-        interface ComplexNestedMoonshineChild {
-            @Message("test")
-            String test();
-
-            @Message("oke")
-            ComplexNestedMoonshineChildChild oke();
-
-            @MessageSection("ok")
-            interface ComplexNestedMoonshineChildChild {
-                @Message("done")
-                String done();
-            }
-        }
-    }
+  }
 }

--- a/core/src/test/java/net/kyori/moonshine/NestedMoonshineTest.java
+++ b/core/src/test/java/net/kyori/moonshine/NestedMoonshineTest.java
@@ -1,0 +1,82 @@
+package net.kyori.moonshine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.leangen.geantyref.TypeToken;
+import net.kyori.moonshine.annotation.Message;
+import net.kyori.moonshine.annotation.MessageSection;
+import net.kyori.moonshine.exception.scan.UnscannableMethodException;
+import net.kyori.moonshine.message.IMessageSource;
+import net.kyori.moonshine.strategy.StandardPlaceholderResolverStrategy;
+import net.kyori.moonshine.strategy.supertype.StandardSupertypeThenInterfaceSupertypeStrategy;
+import net.kyori.moonshine.util.Unit;
+import org.junit.jupiter.api.Test;
+
+class NestedMoonshineTest {
+    @Test
+    void simpleNestedMoonshine() throws UnscannableMethodException {
+        SimpleNestedMoonshineRoot root = moonshineWith(SimpleNestedMoonshineRoot.class, (receiver, messageKey) -> {
+            if ("test".equals(messageKey)) {
+                return "ok";
+            }
+            return null;
+        });
+        assertEquals("ok", root.child().test());
+    }
+
+    @Test
+    void complexNestedMoonshine() throws UnscannableMethodException {
+        ComplexNestedMoonshineRoot root = moonshineWith(ComplexNestedMoonshineRoot.class, (receiver, messageKey) -> {
+            if ("complex.child.child-test".equals(messageKey)) {
+                return "ok";
+            }
+            if ("complex.child.child-oke-ok.done".equals(messageKey)) {
+                return "yes";
+            }
+            return null;
+        });
+        assertEquals("ok", root.child().test());
+        assertEquals("yes", root.child().oke().done());
+    }
+
+    private <T> T moonshineWith(Class<T> type, IMessageSource<Unit, ?> sourced) throws UnscannableMethodException {
+        return Moonshine.<T, Unit>builder(TypeToken.get(type))
+                .receiverLocatorResolver((method, proxy) -> (method1, proxy1, arguments) -> null, 1)
+                .sourced(sourced)
+                .rendered((receiver, intermediateMessage, resolvedPlaceholders, method, owner) -> intermediateMessage)
+                .sent((receiver, renderedMessage) -> {})
+                .resolvingWithStrategy(new StandardPlaceholderResolverStrategy<>(new StandardSupertypeThenInterfaceSupertypeStrategy(false)))
+                .create();
+    }
+
+    interface SimpleNestedMoonshineRoot {
+        SimpleNestedMoonshineChild child();
+
+        @MessageSection
+        interface SimpleNestedMoonshineChild {
+            @Message("test")
+            String test();
+        }
+    }
+
+    @MessageSection("complex")
+    interface ComplexNestedMoonshineRoot {
+        @Message("child")
+        ComplexNestedMoonshineChild child();
+
+        @MessageSection(value = "child", delimiter = '-')
+        interface ComplexNestedMoonshineChild {
+            @Message("test")
+            String test();
+
+            @Message("oke")
+            ComplexNestedMoonshineChildChild oke();
+
+            @MessageSection("ok")
+            interface ComplexNestedMoonshineChildChild {
+                @Message("done")
+                String done();
+            }
+        }
+    }
+}

--- a/standard/src/main/java/net/kyori/moonshine/exception/UnfinishedPlaceholderException.java
+++ b/standard/src/main/java/net/kyori/moonshine/exception/UnfinishedPlaceholderException.java
@@ -30,7 +30,7 @@ public final class UnfinishedPlaceholderException extends PlaceholderResolvingEx
     super("The placeholder "
         + placeholderName
         + " was unfinished in method: "
-        + ReflectiveUtils.formatMethodName(moonshineMethod.owner().getType(), moonshineMethod.reflectMethod()));
+        + ReflectiveUtils.formatMethodName(moonshineMethod.owner(), moonshineMethod.reflectMethod()));
     this.moonshineMethod = moonshineMethod;
     this.placeholderName = placeholderName;
     this.placeholderValue = placeholderValue;

--- a/standard/src/main/java/net/kyori/moonshine/strategy/StandardPlaceholderResolverStrategy.java
+++ b/standard/src/main/java/net/kyori/moonshine/strategy/StandardPlaceholderResolverStrategy.java
@@ -130,7 +130,7 @@ public final class StandardPlaceholderResolverStrategy<R, I, F> implements
 
             final var resolverResult =
                 placeholderResolver.resolve(continuancePlaceholderName, value, receiver,
-                    moonshineMethod.owner().getType(),
+                    moonshineMethod.owner(),
                     moonshineMethod.reflectMethod(), parameters);
             if (resolverResult == null) {
               // The resolver did not want to resolve this; pass it on.


### PR DESCRIPTION
This PR adds support for nested message sections like:
```java
public interface RootSection {
    HelloSection hello();

    @MessageSection("hello")
    interface HelloSection {
        @Message("world")
        String world(@Receiver User user);
    }
}
```
and
```java
@MessageSection("hello")
public interface HelloSection {
    @Message("world")
    WorldSection world();

    @MessageSection(delimiter='-')
    interface WorldSection {
        @Message("moonshine")
        String moonshine(@Receiver User user);
    }
}
```
(first one results in key 'hello.world', second one 'hello.world-moonshine')

Please let me know if there are some changes you'd like to see.